### PR TITLE
fixed os.system

### DIFF
--- a/xt32.py
+++ b/xt32.py
@@ -7,4 +7,4 @@ import os, sys
 
 
 # Command
-os.system("{} src/xt32.py".format(python)
+os.system(f"{python} src/xt32.py")


### PR DESCRIPTION
os.system("{} src/xt32.py".format(python) was changed to os.system(f"{python} src/xt32.py")